### PR TITLE
Change order to Payment Pending instead of on-hold

### DIFF
--- a/src/class-wc-gateway-bitpay.php
+++ b/src/class-wc-gateway-bitpay.php
@@ -570,8 +570,8 @@ function woocommerce_bitpay_init()
 
             $this->log('    [Info] Generating payment form for order ' . $order->get_order_number() . '. Notify URL: ' . $this->notification_url);
 
-            // Mark as on-hold (we're awaiting the payment)
-            $order->update_status('on-hold', 'Awaiting payment notification from BitPay.');
+            // Mark as payment pending (we're awaiting the payment)
+            $order->update_status('pending', 'Awaiting payment notification from BitPay.');
 
             $thanks_link = $this->get_return_url($order);
 


### PR DESCRIPTION
I think it makes more sense (and ties in better with other woocommerce payment plugins) to have the plugin stay in the payment pending state (wc-pending) until it has been paid (at which point people can choose through the plugin which state it should be in).

If it goes to on-hold, an order email is fired out to both the shop admin and the customer saying the order has been received but it shouldn't really do this until the payment is confirmed IMO.

Or perhaps if you disagree, we could be given the option to choose this as well?

Thanks