### PR TITLE
Send order number instead of order id to BitPay

### DIFF
--- a/src/class-wc-gateway-bitpay.php
+++ b/src/class-wc-gateway-bitpay.php
@@ -654,7 +654,8 @@ function woocommerce_bitpay_init()
                 $this->log('    [Info] Invoice object created successfully...');
             }
 
-            $invoice->setOrderId((string)$order_id);
+            $order_number = $order->get_order_number();
+            $invoice->setOrderId((string)$order_number);
             $invoice->setCurrency($currency);
             $invoice->setFullNotifications(true);
 


### PR DESCRIPTION
Sending the order number, instead of order id, to BitPay will make the plugin play more nicely with WooCommerce Sequential Order Numbers plugin and means the customer will see the same order number on BitPay as they will see in the rest of their subsequent order correspondance.