### PR TITLE
Upgrades for latest Woocommerce and Wordpress.

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -11,7 +11,13 @@ You must have a BitPay merchant account to use this plugin.  It's free to [sign-
 * [GMP](http://php.net/manual/en/book.gmp.php) or [BCMath](http://php.net/manual/en/book.bc.php) You may have to install GMP as most servers do not come with it, but generally BCMath is already included.
 * [mcrypt](http://us2.php.net/mcrypt)
 * [OpenSSL](http://us2.php.net/openssl) Must be compiled with PHP
+* [PHP5 Curl](http://php.net/manual/en/curl.installation.php) Must be compiled with PHP
 * PHP >= 5.5 (we tested this on 5.5)
+* Be sure to restart apache after the installation:
+
+```bash
+sudo apachectl restart
+```
 
 ## Installation
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -6,12 +6,12 @@ You must have a BitPay merchant account to use this plugin.  It's free to [sign-
 
 ## Server Requirements
 
-* [Wordpress](https://wordpress.org/about/requirements/) >= 3.9 (Older versions will work, but we do not test against those)
-* [WooCommerce](http://docs.woothemes.com/document/server-requirements/) >= 2.2
+* [Wordpress](https://wordpress.org/about/requirements/) >= 4.3.1 (Older versions will work, but we do not test against those)
+* [WooCommerce](http://docs.woothemes.com/document/server-requirements/) >= 2.4.10
 * [GMP](http://php.net/manual/en/book.gmp.php) or [BCMath](http://php.net/manual/en/book.bc.php) You may have to install GMP as most servers do not come with it, but generally BCMath is already included.
 * [mcrypt](http://us2.php.net/mcrypt)
 * [OpenSSL](http://us2.php.net/openssl) Must be compiled with PHP
-* PHP >= 5.4
+* PHP >= 5.5 (we tested this on 5.5)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
           "type": "package",
           "package": {
             "name": "wordpress",
-            "version": "3.8",
+            "version": "4.3.1",
             "dist": {
               "type": "zip",
-              "url": "https://github.com/WordPress/WordPress/archive/3.8.zip"
+              "url": "https://github.com/WordPress/WordPress/archive/4.3.1.zip"
             }
           }
         }

--- a/src/class-wc-gateway-bitpay.php
+++ b/src/class-wc-gateway-bitpay.php
@@ -333,8 +333,8 @@ function woocommerce_bitpay_init()
                 )
             );
 
-            $pairing_form = file_get_contents(plugin_dir_url(__FILE__).'templates/pairing.tpl');
-            $token_format = file_get_contents(plugin_dir_url(__FILE__).'templates/token.tpl');
+            $pairing_form = file_get_contents(plugin_dir_path(__FILE__).'templates/pairing.tpl');
+            $token_format = file_get_contents(plugin_dir_path(__FILE__).'templates/token.tpl');
 
             ?>
             <tr valign="top">

--- a/src/class-wc-gateway-bitpay.php
+++ b/src/class-wc-gateway-bitpay.php
@@ -199,7 +199,6 @@ function woocommerce_bitpay_init()
 
         public function __destruct()
         {
-            $this->log('BitPay Woocommerce payment plugin object destroyed.');
         }
 
         public function is_valid_for_use()


### PR DESCRIPTION
- referring to the log in the __destruct caused FATAL abort
- prefer to use the plugin_dir_path to make this work universally with https urls.